### PR TITLE
Update SyncContent.ps1

### DIFF
--- a/Unreal_Template_Project/XR_Actions/SyncContent.ps1
+++ b/Unreal_Template_Project/XR_Actions/SyncContent.ps1
@@ -23,7 +23,7 @@ function Convert-LineEndings {
 $ProjectPath = Resolve-Path -Path "${PSScriptRoot}\.."
 
 # Get first uproject file (there should not be multiple)
-$ProjectFile = (Get-ChildItem -Path "${ProjectPath}" -Filter *.uproject  | Select-Object -First 1)
+$ProjectFile = (Get-ChildItem -Path "${ProjectPath}" -Name -Filter *.uproject  | Select-Object -First 1)
 $SyncFiles = @($ProjectFile, "CHANGELOG.md", "XR_Template.png")
 
 $FoldersList = @("Content", "Config", "Cloud", "ImEdgeActions", "ToBuild", "Source", "Plugins")


### PR DESCRIPTION
Powershell 7 Get-ChildItem returns full path instead of filename. Adding -Name flag to return the filename (https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.4#-name)